### PR TITLE
Update runtime to GNOME 46

### DIFF
--- a/org.gimp.GIMP.Plugin.LiquidRescale.json
+++ b/org.gimp.GIMP.Plugin.LiquidRescale.json
@@ -3,9 +3,8 @@
     "branch": "2-40",
     "runtime": "org.gimp.GIMP",
     "runtime-version": "stable",
-    "sdk": "org.gnome.Sdk//44",
+    "sdk": "org.gnome.Sdk//46",
     "build-extension": true,
-    "appstream-compose": false,
     "separate-locales": false,
     "build-options": {
         "prefix": "/app/extensions/LiquidRescale",
@@ -52,7 +51,6 @@
             "post-install": [
                 "strip ${FLATPAK_DEST}/plug-ins/*",
                 "install -Dm644 org.gimp.GIMP.Plugin.LiquidRescale.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo/",
-                "appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}",
                 "mkdir $FLATPAK_DEST/help",
                 "mv $FLATPAK_DEST/share/gimp-lqr-plugin/help $FLATPAK_DEST/help/gimp-lqr-plugin",
                 "install -Dm644 -t $FLATPAK_DEST/share/licenses/gimp-lqr-plugin COPYING"

--- a/org.gimp.GIMP.Plugin.LiquidRescale.metainfo.xml
+++ b/org.gimp.GIMP.Plugin.LiquidRescale.metainfo.xml
@@ -3,11 +3,16 @@
   <id>org.gimp.GIMP.Plugin.LiquidRescale</id>
   <extends>org.gimp.GIMP</extends>
   <name>LiquidRescale</name>
-  <summary>LiquidRescale plugin to resize pictures non uniformly while preserving their features, i.e. avoiding distortion of the important parts.</summary>
+  <summary>LiquidRescale GIMP Plugin</summary>
+  <description>
+    <p>LiquidRescale plugin to resize pictures non uniformly while
+    preserving their features, i.e. avoiding distortion of the
+    important parts.</p>
+  </description>
   <url type="homepage">http://liquidrescale.wikidot.com/</url>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
-  <updatecontact>hub_AT_figuiere.net</updatecontact>
+  <update_contact>hub_AT_figuiere.net</update_contact>
   <releases>
     <release date="2013-08-05" version="0.7.2"/>
   </releases>


### PR DESCRIPTION
- update the metainfo
- no longer manually compose